### PR TITLE
Feature: Core styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "typescript.format.enable": true,
   "eslint.format.enable": true,
   "editor.formatOnSave": true,
+  "cssvar.files": [
+    "./packages/app/src/style/app.variables.css",
+  ],
   "[typescript]": {
     "editor.codeLens": true,
     "editor.suggest.showReferences": true,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bengsfort.dev
 
-My personal portfolio/blog.
+My personal portfolio/blog. If you would like to see how I tackled implementation of the project linearly, I tried to implement everything in linear PR's so you can see the entire evolution of the project by viewing the closed/merged PR's.
 
 ## Notes
 
@@ -12,7 +12,9 @@ When developing, for the best experience it is ideal to open the project as a wo
 packages/app - The Preact app for the site.
 packages/server - The Node.js server for the site.
 tools/esbuild - The common ESBuild config for the project.
+tools/esbuild-plugins - All custom ESBuild plugins.
 tools/eslint-config - The eslint config for the project.
+tools/postcss - The postcss config for the project.
 ```
 
 The project is setup as a yarn workspace for ease of maintenenance and separation of UI / server code, as well as tooling. The project is setup so that common configs can be used easily, and packages can easily reference each-other without worrying about the dependencies involved.
@@ -20,3 +22,8 @@ The project is setup as a yarn workspace for ease of maintenenance and separatio
 ## Scripts
 
 - `yarn lint`: Lint all workspaces.
+
+
+## How I made this
+
+1. [Build system](https://github.com/bengsfort/bengsfort.dev/pull/1)

--- a/packages/app/scripts/build.mjs
+++ b/packages/app/scripts/build.mjs
@@ -39,6 +39,9 @@ export const buildUI = (watchMode, entryPoints, outdir, tsconfigPath = `tsconfig
       '.png': `file`,
       '.jpg': `file`,
       '.gif': `file`,
+      // We don't want global/variable files bundled with the normal css.
+      '.global.css': `empty`,
+      '.variables.css': `empty`,
     },
 
     // Plugins

--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -1,4 +1,3 @@
 .header {
-  font-weight: 800;
-  font-family: 'Poppins', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  margin-top: 0;
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,6 +1,9 @@
 import {FunctionComponent} from 'preact';
+import 'modern-normalize';
 
-import styles              from './App.module.css';
+import './style/app.variables.css';
+import './style/app.global.css';
+import styles from './App.module.css';
 
 interface Props {
   target?: string;
@@ -10,9 +13,3 @@ export const App: FunctionComponent<Props> = ({target}) => {
     <h1 className={styles.header}>Hello, {target}</h1>
   );
 };
-
-
-// export function App({target = `world`}: Props): FunctionComponent<Props> {
-//   return (
-//   );
-// }

--- a/packages/app/src/style/app.global.css
+++ b/packages/app/src/style/app.global.css
@@ -1,0 +1,40 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  color: var(--color-text);
+  font-size: var(--text-size);
+  font-family: var(--font-main);
+  background-color: var(--color-bg);
+}
+
+h1, .h1 {
+  font-weight: var(--weight-bold);
+  font-size: var(--text-h1);
+  font-family: var(--font-main);
+}
+
+h2, .h2 {
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-h2);
+  font-family: var(--font-main);
+}
+
+h3, .h3 {
+  font-weight: var(--weight-bold);
+  font-size: var(--text-h3);
+  font-family: var(--font-main);
+}
+
+h4, .h4 {
+  font-weight: var(--weight-bold);
+  font-size: var(--text-h4);
+  font-family: var(--font-main);
+}
+
+code, pre {
+  font-weight: var(--weight-regular);
+  font-size: var(--text-size);
+  font-family: var(--font-mono);
+}

--- a/packages/app/src/style/app.variables.css
+++ b/packages/app/src/style/app.variables.css
@@ -1,0 +1,32 @@
+:root {
+  /** Colors */
+  --color-light: #e6e6e6;
+  --color-dark: #202020;
+  --color-grey: #2c2c2c;
+  --color-primary: #2365e1;
+  --color-primary-dark: #1a479c;
+  --color-primary-light: #4a82ed;
+  --color-accent-dark: #19253b;
+  --color-accent-light: #262736;
+
+  /** Main elements */
+  --color-bg: var(--color-dark);
+  --color-text: var(--color-light);
+
+  /** Typography */
+  --font-main: 'Poppins', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  --font-mono: 'Ubuntu Mono', monospace;
+
+  --weight-bold: 700;
+  --weight-semibold: 600;
+  --weight-regular: 400;
+
+  --text-size: 22px;
+  --text-large: 28px;
+  --text-small: 18px;
+
+  --text-h1: 36px;
+  --text-h2: 32px;
+  --text-h3: 28px;
+  --text-h4: 24px;
+}

--- a/packages/server/scripts/build.mjs
+++ b/packages/server/scripts/build.mjs
@@ -19,6 +19,9 @@ export const buildApp = watchMode => {
     // File handling
     loader: {
       '.html': `file`,
+      // We don't want global/variable files bundled with the normal css.
+      '.global.css': `empty`,
+      '.variables.css': `empty`,
     },
     external: [],
 
@@ -29,9 +32,6 @@ export const buildApp = watchMode => {
       // within the tree so that we can inject them into the DOM before sending SSR'd
       // markup back to the browser.
       cssModulesPlugin([
-        ...postcssPlugins,
-      ]),
-      globalPostcssPlugin([
         ...postcssPlugins,
       ]),
       exposeCssModules(),

--- a/packages/server/src/bundle/index.html
+++ b/packages/server/src/bundle/index.html
@@ -4,12 +4,19 @@
 <head>
     <title>Bengsfort.dev</title>
 
-    <!-- Google Fonts-->
+    <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
         href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Ubuntu+Mono&display=swap"
         rel="stylesheet">
+
+    <!-- Global styles -->
+    <link href="./assets/style_app.variables.css" rel="stylesheet" />
+    <link href="./assets/style_app.global.css" rel="stylesheet" />
+
+    <!-- Normalize -->
+    <link href="./assets/index.css" rel="stylesheet" />
 
     <!-- @__INITIAL_STATE__-->
 </head>

--- a/tools/esbuild-plugins/src/postcss-global-css-plugin.mjs
+++ b/tools/esbuild-plugins/src/postcss-global-css-plugin.mjs
@@ -7,6 +7,7 @@ const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const ensureDir = util.promisify(fs.ensureDir);
 
+/** @return {import('esbuild').Plugin} */
 export const globalPostcssPlugin = (
   /** @type {import('postcss').Plugin[]} */
   plugins = [],
@@ -16,13 +17,16 @@ export const globalPostcssPlugin = (
     build.onResolve(
       {filter: /\.global?|variables?\.css$/},
       async args => {
+        const {outdir, entryNames} = build.initialOptions;
+
         // Get the file to read
         const sourceFullPath = path.resolve(args.resolveDir, args.path);
 
         // Get the dist file
         const pathName = args.path.replace(`./`, ``).replaceAll(`/`, `_`);
-        const distFilePath = path.resolve(build.initialOptions.outdir, pathName);
-        await ensureDir(build.initialOptions.outdir);
+        const distFilePath = path.resolve(outdir, entryNames.replace(`[name]`, pathName));
+        await ensureDir(outdir);
+        await ensureDir(path.dirname(distFilePath));
 
         // Get the css
         const css = await readFile(sourceFullPath);

--- a/tools/esbuild-plugins/src/postcss-modules-plugin.mjs
+++ b/tools/esbuild-plugins/src/postcss-modules-plugin.mjs
@@ -86,7 +86,7 @@ const onResolveFactory = (
   await ensureDir(tmpDir);
   const tmpFilePath = path.resolve(tmpDir, `${sourceBaseName}.css`);
 
-  const {jsContent} = await buildCssModulesJS(sourceFullPath, plugins, target === `node`);
+  const {jsContent} = await buildCssModulesJS(sourceFullPath, plugins, target.includes(`node`));
 
   await writeFile(`${tmpFilePath}.js`, jsContent, {encoding: `utf-8`});
 

--- a/tools/postcss/src/stylelint.cjs
+++ b/tools/postcss/src/stylelint.cjs
@@ -14,7 +14,7 @@ module.exports = {
     "no-missing-end-of-source-newline": true,
     "at-rule-no-unknown": [true, {ignoreAtRules: [`define-mixin`, `mixin`]}],
     "unit-allowed-list": [
-      [`rem`, `ms`, `%`, `deg`, `vw`, `vh`, `fr`],
+      [`px`, `rem`, `ms`, `%`, `deg`, `vw`, `vh`, `fr`],
       {ignoreProperties: {em: [`letter-spacing`], px: [`/border-*/`, `box-shadow`, `backdrop-filter`, `filter`]}},
     ],
     "declaration-block-no-duplicate-properties": true,


### PR DESCRIPTION
Mainly serves as a test bed of usage of postcss + esbuild + ssr, by implementing all of the core variables from the design I made in sketch into global css files and getting them into the template.

While doing this, I discovered some issues with the current stack specifically with regards to SSR. Primarily, that the css module esbuild plugin doesn't really work optimally with SSR. This is because the esbuild plugin has to inject some JS that with create a style node for every module with the correct digest/hash; which works in the browser but presents some challenges when importing the modules in node, rendering to a string, and manually injecting it into the html template as we don't have the references to any of those.

This could be handled manually by utilising esbuild _at runtime on the server_ to create a semi-static site implementation, which would be really fun to implement, but as I have limited time to work on this I've decided to shelf that and use Vite instead to get what I'm looking for but with less effort, boilerplate, and time investment.